### PR TITLE
Pinned mongodb chart version to 0.9.0 as the newest one fails to install

### DIFF
--- a/okteto.yml
+++ b/okteto.yml
@@ -4,7 +4,7 @@ dependencies:
 
 deploy:
   commands:
-    - helm upgrade --install mongodb oci://registry-1.docker.io/cloudpirates/mongodb --values mongodb-values.yaml --wait --timeout=10m
+    - helm upgrade --install mongodb oci://registry-1.docker.io/cloudpirates/mongodb --values mongodb-values.yaml --wait --timeout=10m --version 0.9.0
     - kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=mongodb --timeout=300s
     - sleep 10
     - kubectl exec statefulset/mongodb -- mongosh -u root -p $(kubectl get secret mongodb -o jsonpath='{.data.mongodb-root-password}' | base64 -d) --eval "db = db.getSiblingDB('okteto'); db.createUser({user:'okteto', pwd:'okteto', roles:[{role:'readWrite', db:'okteto'}]}); print('Created okteto user successfully');"


### PR DESCRIPTION
The error I was getting with the latest version was

```
Digest: sha256:5d1c7a04e5483ba59c70736560b1b87b206c8da7f3a6982b7d6fca79a2f2a40dError: YAML parse error on mongodb/templates/configmap.yaml: error converting YAML to JSON: yaml: line 7: mapping values are not allowed in this context
```